### PR TITLE
Improve logic to guess Flags/String for INFO fields not in header

### DIFF
--- a/cyvcf/parser.pyx
+++ b/cyvcf/parser.pyx
@@ -869,10 +869,10 @@ cdef class Reader(object):
             elif ID in RESERVED_INFO:
                 entry_type = RESERVED_INFO[ID]
             else:
-                if entry[1]:
-                    entry_type = 'String'
-                else:
+                if len(entry) == 1:
                     entry_type = 'Flag'
+                else:
+                    entry_type = 'String'
 
             """
             try:


### PR DESCRIPTION
Aaron and Brent;
This is a small one I noticed while debugging a parsing issue. The prior code would fail for flags not in the header since it checked the presence of the second field with an `1` index on a single value `entry` list. Thanks much.