### PR TITLE
update _vcf_metadata_parser to match pyvcf

### DIFF
--- a/cyvcf/parser.pyx
+++ b/cyvcf/parser.pyx
@@ -101,22 +101,33 @@ class _vcf_metadata_parser(object):
     def __init__(self):
         super(_vcf_metadata_parser, self).__init__()
         self.info_pattern = re.compile(r'''\#\#INFO=<
-            ID=(?P<id>[^,]+),
-            Number=(?P<number>-?\d+|\.|[ARG]),
-            Type=(?P<type>Integer|Float|Flag|Character|String),
+            ID=(?P<id>[^,]+),\s*
+            Number=(?P<number>-?\d+|\.|[AGR]),\s*
+            Type=(?P<type>Integer|Float|Flag|Character|String),\s*
             Description="(?P<desc>[^"]*)"
+            (?:,\s*Source="(?P<source>[^"]*)")?
+            (?:,\s*Version="?(?P<version>[^"]*)"?)?
             >''', re.VERBOSE)
         self.filter_pattern = re.compile(r'''\#\#FILTER=<
-            ID=(?P<id>[^,]+),
+            ID=(?P<id>[^,]+),\s*
+            Description="(?P<desc>[^"]*)"
+            >''', re.VERBOSE)
+        self.alt_pattern = re.compile(r'''\#\#ALT=<
+            ID=(?P<id>[^,]+),\s*
             Description="(?P<desc>[^"]*)"
             >''', re.VERBOSE)
         self.format_pattern = re.compile(r'''\#\#FORMAT=<
-            ID=(?P<id>.+),
-            Number=(?P<number>-?\d+|\.|[ARG]),
-            Type=(?P<type>.+),
+            ID=(?P<id>.+),\s*
+            Number=(?P<number>-?\d+|\.|[AGR]),\s*
+            Type=(?P<type>.+),\s*
             Description="(?P<desc>.*)"
             >''', re.VERBOSE)
-        self.meta_pattern = re.compile(r'''##(?P<key>.+)=(?P<val>.+)''')
+        self.contig_pattern = re.compile(r'''\#\#contig=<
+            ID=(?P<id>[^>,]+)
+            (,.*length=(?P<length>-?\d+))?
+            .*
+            >''', re.VERBOSE)
+        self.meta_pattern = re.compile(r'''##(?P<key>.+?)=(?P<val>.+)''')
 
     def read_info(self, info_string):
         '''Read a meta-information INFO line.'''


### PR DESCRIPTION
I was getting errors with a VCF file that had a header that did not validate with cyvcf but did with pyvcf, due to an info line containing a `Version`.  I updated the metadata parser to match the mirrored section in pyvcf. My file now parses correctly and all tests pass. 

```
##INFO=<ID=VDB,Number=1,Type=Float,Description="Variant Distance Bias for filtering splice-site artefacts in RNA-seq data (bigger is better)",Version="3">
```
